### PR TITLE
Allow gnupghome to be set from an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ configure `:gpg_gnupghome:` in your hiera.yaml (under the `:eyaml:` section). Th
 directory that contains the keyring etc for the user that can to decrypt the hiera data. Please note
 that the private GPG key must not have a passphrase.
 
+For command line uses such as `puppet lookup` where the `gpg_gnupghome` setting in the `hiera.yaml`
+configuration does not match a directory the user has access to, you can override the `gpg_gnupghome`
+setting by setting the path in the environment variable `HIERA_EYAML_GPG_GNUPGHOME` and, if set, that
+will be used instead of `gpg_gnupghome`.
+
+    $ HIERA_EYAML_GPG_GNUPGHOME=~/.gnupg puppet lookup my_key
+
 Authors
 -------
 

--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -58,7 +58,11 @@ class Hiera
           end
 
           def self.gnupghome
-            gnupghome = self.option :gnupghome
+            gnupghome = if ENV['HIERA_EYAML_GPG_GNUPGHOME'].nil?
+                          self.option :gnupghome
+                        else
+                          ENV['HIERA_EYAML_GPG_GNUPGHOME']
+                        end
             debug("GNUPGHOME is #{gnupghome}")
             if gnupghome.nil? || gnupghome.empty?
               warn("No GPG home directory configured, check gpg_gnupghome configuration value is correct")


### PR DESCRIPTION
This allows setting of the environment variable `HIERA_EYAML_GPG_GNUPGHOME` to override the setting of `gpg_gnupghome` set in `hiera.yaml`.

The use case for this is that a user attempting to run a Puppet command as themselves (e.g. `puppet lookup`) will encounter an error when hiera-eyaml-gpg attempts to access the directory set in `hiera.yaml`'s `gpg_gnupghome` option (which should only be accessible to the Puppetserver user).