### PR TITLE
Use Puppet::Util::Execution for RubyGpg

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -6,6 +6,7 @@ rescue LoadError
   rescue LoadError
     fail "hiera-eyaml-gpg requires either the 'gpgme' or 'ruby_gpg' gem"
   end
+  require 'hiera/backend/eyaml/encryptors/gpg/puppet_gpg'
 end
 
 require 'base64'
@@ -163,8 +164,9 @@ class Hiera
             gnupghome = self.gnupghome
 
             unless defined?(GPGME)
-              RubyGpg.config.homedir = gnupghome if gnupghome
-              return RubyGpg.decrypt_string(ciphertext)
+              gpg = Hiera::Backend::Eyaml::GpgPuppetserver
+              gpg.config.homedir = gnupghome if gnupghome
+              return gpg.decrypt_string(ciphertext)
             end
 
             GPGME::Engine.home_dir = gnupghome

--- a/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
@@ -1,0 +1,29 @@
+require 'puppet/util/execution'
+require 'puppet/file_system/uniquefile'
+
+class Hiera
+module Backend
+module Eyaml
+module GpgPuppetserver
+  extend RubyGpg
+
+  def self.run_command(command, input = nil)
+    tmpfile = Puppet::FileSystem::Uniquefile.new('puppet-eyaml-hiera-gpg-input', modes: File::WRONLY|File::BINARY)
+    tmpfile.write(input)
+    tmpfile.close
+
+    real_command = "#{command} #{tmpfile.path}"
+
+    output = Puppet::Util::Execution.execute(real_command)
+    tmpfile.unlink
+
+    if output.exitstatus != 0
+      raise "GPG command (#{real_command}) failed with status #{output.exitstatus}: '#{output}'"
+    end
+
+    output
+  end
+end
+end
+end
+end


### PR DESCRIPTION
I don't know if this should be merged or not, but I am providing it at least as a reference for anyone else who might encounter this problem.

RubyGpg is used when Gpgme isn't available, which will always be the case for Puppetserver-based execution. However, when running from Puppetserver `Puppet::Util::Execution.execute()` should be used to invoke external commands and RubyGpg does not do that.

This patch basically monkeypatches RubyGpg so that `Puppet::Util::Execution.execute()` is used, which will address issues on Puppetserver deployments (particularly ones with large heap sizes).

Probably a better way to go about this would be some more fundamental changes so that RubyGpg isn't needed (and therefore doesn't need to be monkeypatched) but that was beyond the scope of what I was ready to take on.

Note that this patch modifies the command passed in with an appended tempfile path instead of passing the key in on `stdin` (which I feel would be a cleaner way of handling it) because of this Puppet bug: https://tickets.puppetlabs.com/browse/PUP-9304