### PR TITLE
Fix `uninitialized constant Puppet (NameError)`

### DIFF
--- a/hiera-eyaml-gpg.gemspec
+++ b/hiera-eyaml-gpg.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency('hiera-eyaml', '>=1.3.8')
+  gem.add_dependency('puppet', '>=5.5.8')
 end

--- a/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
@@ -1,3 +1,4 @@
+require 'puppet'
 require 'puppet/util/execution'
 require 'puppet/file_system/uniquefile'
 


### PR DESCRIPTION
When running from the command line when `gpgme` isn't installed
(but `ruby_gpg` is), `eyaml` dies with...

```
uninitialized constant Puppet (NameError)
```

This fix makes decryption possible with `ruby_gpg` and encryption
goes back to emitting a helpful error message about only supporting
`gpgme`.

Full stacktrace.
```
/home/fishera/.rvm/gems/ruby-2.4.6/gems/puppet-6.4.1/lib/puppet/file_system.rb:1:in `<top (required)>': uninitialized constant Puppet (NameError)
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/puppet-6.4.1/lib/puppet/file_system/uniquefile.rb:1:in `require'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/puppet-6.4.1/lib/puppet/file_system/uniquefile.rb:1:in `<top (required)>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/puppet-6.4.1/lib/puppet/util/execution.rb:2:in `require'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/puppet-6.4.1/lib/puppet/util/execution.rb:2:in `<top (required)>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb:2:in `require'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb:2:in `<top (required)>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:9:in `require'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:9:in `rescue in <top (required)>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:1:in `<top (required)>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg/eyaml_init.rb:1:in `require'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg/eyaml_init.rb:1:in `<top (required)>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:50:in `load'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:50:in `block (2 levels) in find'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:34:in `each'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:34:in `block in find'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:31:in `each'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:31:in `find'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/bin/eyaml:10:in `<top (required)>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/eyaml:23:in `load'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/eyaml:23:in `<main>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/ruby_executable_hooks:24:in `eval'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/ruby_executable_hooks:24:in `<main>'
```