### PR TITLE
Fix `<module:Encryptors>: Gpg is not a class (TypeError)`

### DIFF
--- a/hiera-eyaml-gpg.gemspec
+++ b/hiera-eyaml-gpg.gemspec
@@ -4,7 +4,7 @@ require 'hiera/backend/eyaml/encryptors/gpg/version'
 
 Gem::Specification.new do |gem|
   gem.name          = 'hiera-eyaml-gpg'
-  gem.version       = Hiera::Backend::Eyaml::Encryptors::Gpg::VERSION
+  gem.version       = Hiera::Backend::Eyaml::Encryptors::GpgVersion::VERSION
   gem.description   = 'GPG encryptor for use with hiera-eyaml'
   gem.summary       = 'Encryption plugin for hiera-eyaml backend for Hiera'
   gem.author        = 'Simon Hildrew'

--- a/lib/hiera/backend/eyaml/encryptors/gpg/version.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg/version.rb
@@ -2,7 +2,7 @@ class Hiera
   module Backend
     module Eyaml
       module Encryptors
-        module Gpg
+        module GpgVersion
           VERSION = '0.6'.freeze
         end
       end


### PR DESCRIPTION
Solution borrowed from https://github.com/craigwatson/hiera-eyaml-gkms/commit/fa4551fce113cf59e00d4e14b82d845d148bb462

```
/home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:22:in `<module:Encryptors>': Gpg is not a class (TypeError)
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:21:in `<module:Eyaml>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:20:in `<module:Backend>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:19:in `<class:Hiera>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg.rb:18:in `<top (required)>'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg/eyaml_init.rb:1:in `require'
	from /home/fishera/github/hiera-eyaml-gpg/lib/hiera/backend/eyaml/encryptors/gpg/eyaml_init.rb:1:in `<top (required)>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:50:in `load'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:50:in `block (2 levels) in find'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:34:in `each'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:34:in `block in find'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:31:in `each'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/lib/hiera/backend/eyaml/plugins.rb:31:in `find'
	from /home/fishera/.rvm/gems/ruby-2.4.6/gems/hiera-eyaml-3.0.0/bin/eyaml:10:in `<top (required)>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/eyaml:23:in `load'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/eyaml:23:in `<main>'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/ruby_executable_hooks:24:in `eval'
	from /home/fishera/.rvm/gems/ruby-2.4.6/bin/ruby_executable_hooks:24:in `<main>'
```