### PR TITLE
Expose plugin version

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -20,6 +20,7 @@ class Hiera
     module Eyaml
       module Encryptors
         class Gpg < Encryptor
+          VERSION = Hiera::Backend::Eyaml::Encryptors::GpgVersion::VERSION
           self.tag = 'GPG'
 
           self.options = {


### PR DESCRIPTION
When running `eyaml version -n gpg`...

before this commit
```
[hiera-eyaml-core] hiera-eyaml (core): 3.0.0
[hiera-eyaml-core] hiera-eyaml-gpg (gem): unknown (is plugin compatible with eyaml 2.0+ ?)
```

after this commit
```
[hiera-eyaml-core] hiera-eyaml (core): 3.0.0
[hiera-eyaml-core] hiera-eyaml-gpg (gem): 0.6
```