### PR TITLE
Remove gem dependency on `puppet`

### DIFF
--- a/hiera-eyaml-gpg.gemspec
+++ b/hiera-eyaml-gpg.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency('hiera-eyaml', '>=1.3.8')
-  gem.add_dependency('puppet', '>=5.5.8')
 end


### PR DESCRIPTION
Fixes
```
Error installing hiera-eyaml-gpg:
	"puppet" from puppet conflicts with /opt/puppetlabs/puppet/bin/puppet
```