### PR TITLE
Fix uninitialized constant `Hiera::Backend::Eyaml::Encryptors::GpgVer…

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -14,6 +14,7 @@ require 'pathname'
 require 'hiera/backend/eyaml/encryptor'
 require 'hiera/backend/eyaml/utils'
 require 'hiera/backend/eyaml/options'
+require 'hiera/backend/eyaml/encryptors/gpg/version'
 
 class Hiera
   module Backend


### PR DESCRIPTION
…sion`

Not sure why this wasn't a problem when testing `eyaml version -n gpg`,
but without this `require` the gem is unuseable on the puppetserver :(

With this fix, everything, (finally), seems ok on the puppetserver.

Fixes
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, uninitialized constant Hiera::Backend::Eyaml::Encryptors::GpgVersion
```