### PR TITLE
Don't merge stderr into stdout for GPG Output. 

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
@@ -15,7 +15,7 @@ class Hiera
 
           real_command = "#{command} #{tmpfile.path}"
 
-          output = Puppet::Util::Execution.execute(real_command, { combine: false, failonfail: true })
+          output = Puppet::Util::Execution.execute(real_command, combine: false, failonfail: true )
           tmpfile.unlink
 
           if output.exitstatus != 0

--- a/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
@@ -15,7 +15,7 @@ class Hiera
 
           real_command = "#{command} #{tmpfile.path}"
 
-          output = Puppet::Util::Execution.execute(real_command, combine: false, failonfail: true )
+          output = Puppet::Util::Execution.execute(real_command, combine: false, failonfail: true)
           tmpfile.unlink
 
           if output.exitstatus != 0

--- a/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg/puppet_gpg.rb
@@ -15,7 +15,7 @@ class Hiera
 
           real_command = "#{command} #{tmpfile.path}"
 
-          output = Puppet::Util::Execution.execute(real_command)
+          output = Puppet::Util::Execution.execute(real_command, { combine: false, failonfail: true })
           tmpfile.unlink
 
           if output.exitstatus != 0


### PR DESCRIPTION
This change makes it so that STDERR isn't merged into STDOUT when
retrieving values from GPG, so warnings no longer get added to stdout.

Fixes #68 
